### PR TITLE
ci: add gitleaks secret-scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,33 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan PR diff
+        run: |
+          gitleaks git \
+            --log-opts "origin/${{ github.base_ref }}..HEAD" \
+            --redact \
+            --verbose


### PR DESCRIPTION
Adds the standalone `Secret Scan (gitleaks)` workflow required by the org-level ruleset [erphq-secret-scan](https://github.com/organizations/erphq/settings/rules/15240088).

Runs on PRs to `main`: scans the PR diff for secrets using gitleaks v8.30.1 (redacted output).

Ruleset is currently in `evaluate` mode — it logs violations but does not block merges. Once this workflow is merged across all erphq repos, the ruleset will be flipped to `active`.
