### PR TITLE
chore: standardize brand to ERP•AI in license and readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2025] [ERP.AI]
+   Copyright [2025] [ERP•AI]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This research project implements a novel approach to process mining using Graph 
 
 - **Somesh Misra** [@mathprobro](https://x.com/mathprobro)
 - **Shashank Dixit** [@sphinx](https://x.com/protosphinx)
-- **Research Group**: [ERP.AI](https://www.erp.ai) Research
+- **Research Group**: [ERP•AI](https://www.erp.ai) Research
 
 ## 3. Key Components
 
@@ -64,7 +64,7 @@ src/
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/ERPdotAI/GNN.git
+git clone https://github.com/erphq/GNN.git
 cd GNN
 ```
 
@@ -141,7 +141,7 @@ If you use this code in your research, please cite:
   author = {Shashank Dixit/Somesh Misra},
   title = {Process Mining with Graph Neural Networks},
   year = {2025},
-  publisher = {ERP.AI},
-  url = {https://github.com/ERPdotAI/GNN}
+  publisher = {ERP•AI},
+  url = {https://github.com/erphq/GNN}
 }
 ``` 


### PR DESCRIPTION
Standardize brand references to `ERP•AI` across surface docs and align LICENSE copyright year to each repo's first-commit year.

## Scope (this repo)

- Brand normalization in `.md` files: `ERP·AI`, `ERP.AI`, and brand-prose `erp.ai` → `ERP•AI`
- LICENSE updated to canonical `ERP•AI` form; copyright year aligned to this repo's first-commit year
- GitHub org URLs: `ERPdotAI` → `erphq` (where applicable)
- Install scripts: `REPO=ERPdotAI/...` → `REPO=erphq/...` (where applicable)

## Preserved intentionally

- Email addresses (`legal@erp.ai`, `press@erp.ai`, etc.)
- URLs and subdomains (`https://erp.ai/...`, `docs.erp.ai`, `api.erp.ai`, `www.erp.ai`)
- Repo/skill/directory identifiers (`erpai-cli`, `erpai-ops`, `erpai-cloudflare`, etc.)
- Third-party LICENSE holders (`neo`: Neo Contributors, `gitlab-mr-mcp`: GitLab MCP Server)

## Out of scope — flagged for later sweep

- HTML templates, TSX/React, `Cargo.toml`, `package.json`
- Nunjucks templates
- `GITHUB_HYGIENE_*.md` (documents the aliases themselves)
