### PR TITLE
ci: add gitleaks secret-scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,33 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan PR diff
+        run: |
+          gitleaks git \
+            --log-opts "origin/${{ github.base_ref }}..HEAD" \
+            --redact \
+            --verbose


### PR DESCRIPTION
## Summary
Adds `.github/workflows/secret-scan.yml` — a gitleaks diff-scope scan on PRs to `main`.

## Why
The `erphq-secret-scan` org ruleset (active since 2026-04-18) requires a `Secret Scan (gitleaks)` status check on default-branch PRs for every non-excluded repo. `GNN` was part of that set but had **no `.github/workflows/` directory at all**, so any PR against main would block indefinitely on a check that never reports.

Originally the ruleset excluded `website` and `erpai-cli`; `erpai-cli` (empty repo) was dropped from that exclusion earlier today. `GNN` was never excluded — the gap was just latent until the first PR.

## Shape
Same canonical workflow used by `proto`, `skills`, `erpai-cli-releases`:
- Trigger: `pull_request` → `main`
- `concurrency` group cancels superseded runs
- gitleaks `8.30.1` pinned
- Scans `origin/<base_ref>..HEAD` (PR diff scope only)

## Test plan
- [ ] CI on this PR shows the `Secret Scan (gitleaks)` job running and green (no secrets in the `.github/workflows/` diff).
- [ ] After merge, the `Secret Scan (gitleaks)` context appears selectable in branch-protection / ruleset UI.
- [ ] Next PR against GNN/main completes the ruleset check cleanly.