### PR TITLE
chore: docker image + ghcr workflow + post-audit correctness fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+name: docker
+
+# Builds the image on every push to main, and again on every release tag.
+# Tags emitted:
+#   - main pushes  → ghcr.io/erphq/gnn:main + :sha-<short>
+#   - tag v0.2.0   → ghcr.io/erphq/gnn:0.2.0 + :0.2 + :latest
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".github/workflows/docker.yml"
+      - "requirements.txt"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/gnn
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: log in to ghcr
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,prefix=sha-
+
+      - name: build (and push if not PR)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Slim CPU image. CUDA images are much larger and most users running this
+# in a container are doing batch / CI work where CPU is fine.
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# System deps:
+# - graphviz/libgomp: required by some PyG / sklearn paths
+# - git: pip needs it for any VCS-style installs (none today, but cheap)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libgomp1 \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install CPU torch first, then the rest of the stack — the CPU index
+# avoids pulling the multi-GB CUDA wheels.
+RUN pip install --index-url https://download.pytorch.org/whl/cpu torch
+
+COPY requirements.txt pyproject.toml README.md LICENSE ./
+RUN pip install -r requirements.txt
+
+# Source code goes after the deps so a code-only edit doesn't bust the
+# pip cache.
+COPY gnn_cli/ gnn_cli/
+COPY models/ models/
+COPY modules/ modules/
+COPY visualization/ visualization/
+COPY main.py ./
+RUN pip install -e .
+
+# Sample data so `gnn run` works on a fresh `docker run` without volume mounts.
+COPY input/ input/
+
+# `gnn` is the canonical entry point, but allow `docker run … python main.py`
+# fallthrough by keeping an empty CMD.
+ENTRYPOINT ["gnn"]
+CMD ["--help"]

--- a/modules/data_preprocessing.py
+++ b/modules/data_preprocessing.py
@@ -53,18 +53,34 @@ def load_and_preprocess_data(
         required_cols = DEFAULT_REQUIRED_COLS
 
     df = pd.read_csv(data_path)
-    df.rename(
-        columns={
-            "case:id": "case_id",
-            "case:concept:name": "case_id",
-            "concept:name": "task_name",
-            "time:timestamp": "timestamp",
-            "org:resource": "resource",
-            "case:Amount": "amount",
-        },
-        inplace=True,
-        errors="ignore",
-    )
+
+    # Priority-based rename: when multiple XES-style aliases map to the
+    # same canonical name (e.g. BPI logs carry both `case:id` and
+    # `case:concept:name`), pick the first present source and drop the
+    # rest, otherwise pandas creates a duplicate-named column that
+    # downstream `df["case_id"]` access cannot disambiguate.
+    rename_priorities = {
+        "case_id": ("case:concept:name", "case:id"),
+        "task_name": ("concept:name",),
+        "timestamp": ("time:timestamp",),
+        "resource": ("org:resource",),
+        "amount": ("case:Amount",),
+    }
+    for canonical, sources in rename_priorities.items():
+        if canonical in df.columns:
+            # Already present; drop any aliases that would collide.
+            for src in sources:
+                if src in df.columns:
+                    df.drop(columns=src, inplace=True)
+            continue
+        for src in sources:
+            if src in df.columns:
+                df.rename(columns={src: canonical}, inplace=True)
+                # Drop remaining lower-priority aliases.
+                for other in sources:
+                    if other != src and other in df.columns:
+                        df.drop(columns=other, inplace=True)
+                break
 
     for c in required_cols:
         if c not in df.columns:

--- a/modules/rl_optimization.py
+++ b/modules/rl_optimization.py
@@ -43,9 +43,12 @@ class ProcessEnv:
         Currently using one-hot encoding for current task
         Could be extended with more features
         """
-        state_vec = np.zeros(len(self.all_tasks), dtype=np.float32)
-        idx = self.current_task
-        state_vec[idx] = 1.0
+        # Size by the full label space, not `all_tasks`. Some encoded
+        # task_ids only appear as `next_task` and are dropped from `df`
+        # before `all_tasks` is computed, but `current_task` can still
+        # take any value in [0, len(le_task.classes_)).
+        state_vec = np.zeros(len(self.le_task.classes_), dtype=np.float32)
+        state_vec[self.current_task] = 1.0
         return state_vec
     
     def step(self, action):


### PR DESCRIPTION
## Docker / packages

- **Dockerfile**: \`python:3.11-slim\` with CPU torch, full pipeline deps, \`gnn\` CLI as entrypoint, sample \`input/\` baked in. Layered so source-only edits don't bust the dep cache.
- **\`.github/workflows/docker.yml\`**: builds on push-to-main and on \`v*.*.*\` tags, pushes to \`ghcr.io/erphq/gnn\`.
  - Tag scheme: main → \`:main\` + \`:sha-<short>\`; release → \`:X.Y.Z\` + \`:X.Y\` + \`:latest\`.
  - PRs run a build-only sanity check (no push).

This populates the **Packages** widget on the repo home page once it lands on main.

## Correctness fixes that surfaced after merging the audit

- **Priority-based column rename in \`data_preprocessing\`.** BPI logs sometimes carry both \`case:id\` and \`case:concept:name\` (also XES variants). The previous \`df.rename(...)\` would map both onto \`case_id\`, producing a duplicate-named column that broke every downstream \`df["case_id"]\` access. Fixed with explicit priority + dropping aliases.
- **\`rl_optimization.ProcessEnv._get_state\` index out of range.** State vector was sized by \`len(self.all_tasks)\`, but \`self.current_task\` could exceed it. \`all_tasks\` is computed from rows that survive the \`next_task\` filter, so any task that only ever appears as a *final* event of a case is missing from it — yet it can legitimately be the value of \`current_task\`. Now sized by \`len(le_task.classes_)\`.

## Test plan

- [ ] CI green (build-only run on the PR confirms the Dockerfile is sane)
- [ ] On merge: the docker workflow pushes \`ghcr.io/erphq/gnn:main\` and the Packages widget shows 1 package
- [ ] After the next \`v*.*.*\` tag: \`:X.Y.Z\` / \`:X.Y\` / \`:latest\` tags emitted