### PR TITLE
docs: drop broken ASCII-art banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,11 @@
 <div align="center">
 
-```
-   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-   ┃                                                              ┃
-   ┃   ┏━━┓┏┓╻┏┓╻         process mining · graph attention        ┃
-   ┃   ┃┏┓┃┃┗┫┃┗┫         lstm · spectral · tabular rl            ┃
-   ┃   ┃┗┛┃╹ ╹╹ ╹         pm4py · pyo3 hot-paths · single CLI     ┃
-   ┃   ┗━━┛                                                       ┃
-   ┃                                                              ┃
-   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-```
+# `gnn`
 
-# **gnn** — process mining with graph neural networks
+### process mining with graph neural networks
 
 **Predict the next event. Find the bottleneck. Recommend the resource.**
+
 One CLI, one event log, six questions answered.
 
 [![ci](https://github.com/erphq/gnn/actions/workflows/ci.yml/badge.svg)](https://github.com/erphq/gnn/actions/workflows/ci.yml)


### PR DESCRIPTION
The box-drawing 'gnn' banner I added in the previous PR didn't render — letters are garbled and the outer frame misaligns. Replacing with a clean centered H1 + tagline (the pattern ruff / polars / bun use).